### PR TITLE
NIAD-1225: SDS API requests must use X-Correlation-Id

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/CloudGatewayRouteBaseTest.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.gpc.consumer;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -27,6 +28,7 @@ public class CloudGatewayRouteBaseTest {
     protected static final String SSP_INTERACTION_ID_HEADER = "Ssp-InteractionID";
     protected static final String SSP_TRACE_ID_HEADER = "Ssp-TraceID";
     protected static final String ANY_STRING = "any";
+    protected static final String RANDOM_UUID = String.valueOf(UUID.randomUUID());
     protected static final String GET_DOCUMENT_URI = "/GP0001/STU3/1/gpconnect/documents/Binary/07a6483f-732b-461e-86b6-edb665c45510";
     protected static final String EXPECTED_DOCUMENT_BODY = "{"
         + " \"resourceType\": \"Binary\","

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/EnvironmentSdsFilterTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/EnvironmentSdsFilterTest.java
@@ -4,6 +4,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
+import java.util.UUID;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +33,7 @@ public class EnvironmentSdsFilterTest extends CloudGatewayRouteBaseTest {
             .header(SSP_FROM_HEADER, ANY_STRING)
             .header(SSP_TO_HEADER, ANY_STRING)
             .header(SSP_INTERACTION_ID_HEADER, DOCUMENT_INTERACTION_ID)
-            .header(SSP_TRACE_ID_HEADER, ANY_STRING)
+            .header(SSP_TRACE_ID_HEADER, RANDOM_UUID)
             .exchange()
             .expectStatus()
             .isOk()

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/EnvironmentSdsFilterTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/EnvironmentSdsFilterTest.java
@@ -4,8 +4,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
-import java.util.UUID;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
@@ -18,7 +18,6 @@ public class GetStructuredDocumentRouteTest extends CloudGatewayRouteBaseTest {
         + "\"type\":\"collection\",\"entry\":[]}";
     private static final String STRUCTURED_INTERACTION_ID =
         "urn:nhs:names:services:gpconnect:fhir:operation:gpc.getstructuredrecord-1";
-    private static final String RANDOM_UUID = String.valueOf(UUID.randomUUID());
 
     @Test
     public void When_MakingRequestForStructuredDocument_Expect_OkResponse() {

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
@@ -5,8 +5,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
-import java.util.UUID;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 

--- a/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gpc/consumer/GetStructuredDocumentRouteTest.java
@@ -5,6 +5,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
+import java.util.UUID;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +18,7 @@ public class GetStructuredDocumentRouteTest extends CloudGatewayRouteBaseTest {
         + "\"type\":\"collection\",\"entry\":[]}";
     private static final String STRUCTURED_INTERACTION_ID =
         "urn:nhs:names:services:gpconnect:fhir:operation:gpc.getstructuredrecord-1";
+    private static final String RANDOM_UUID = String.valueOf(UUID.randomUUID());
 
     @Test
     public void When_MakingRequestForStructuredDocument_Expect_OkResponse() {
@@ -33,7 +36,7 @@ public class GetStructuredDocumentRouteTest extends CloudGatewayRouteBaseTest {
             .header(SSP_FROM_HEADER, ANY_STRING)
             .header(SSP_TO_HEADER, ANY_STRING)
             .header(SSP_INTERACTION_ID_HEADER, STRUCTURED_INTERACTION_ID)
-            .header(SSP_TRACE_ID_HEADER, ANY_STRING)
+            .header(SSP_TRACE_ID_HEADER, RANDOM_UUID)
             .exchange()
             .expectStatus()
             .isOk()
@@ -57,7 +60,7 @@ public class GetStructuredDocumentRouteTest extends CloudGatewayRouteBaseTest {
             .header(SSP_FROM_HEADER, ANY_STRING)
             .header(SSP_TO_HEADER, ANY_STRING)
             .header(SSP_INTERACTION_ID_HEADER, STRUCTURED_INTERACTION_ID)
-            .header(SSP_TRACE_ID_HEADER, ANY_STRING)
+            .header(SSP_TRACE_ID_HEADER, RANDOM_UUID)
             .exchange()
             .expectStatus()
             .isNotFound()

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
@@ -127,10 +127,10 @@ public class SdsFilter implements GlobalFilter, Ordered {
 
     private String extractSspTraceId(HttpHeaders httpHeaders) {
         if (httpHeaders.containsKey(SSP_TRACE_ID)) {
-            List<String> interactionIds = httpHeaders.get(SSP_TRACE_ID);
+            List<String> sspTraceIds = httpHeaders.get(SSP_TRACE_ID);
 
-            if (!CollectionUtils.isEmpty(interactionIds)) {
-                return interactionIds.get(0);
+            if (!CollectionUtils.isEmpty(sspTraceIds)) {
+                return sspTraceIds.get(0);
             }
         }
         throw new SdsException("Missing Ssp-TraceID Header for X-Correlation-Id for SDS Request");

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/filters/SdsFilter.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import javax.annotation.PostConstruct;
 
@@ -42,6 +42,7 @@ public class SdsFilter implements GlobalFilter, Ordered {
     private static final String DOCUMENT_SEARCH_ID = INTERACTION_ID_PREFIX + "documents:fhir:rest:search:documentreference-1";
     private static final String BINARY_READ_ID = INTERACTION_ID_PREFIX + "documents:fhir:rest:read:binary-1";
     private static final String SSP_INTERACTION_ID = "Ssp-InteractionID";
+    private static final String SSP_TRACE_ID = "Ssp-TraceID";
     private static final String PIPE = "|";
     private static final String COLON = ":";
     private static final String ENCODED_COLON = "%3A";
@@ -49,7 +50,7 @@ public class SdsFilter implements GlobalFilter, Ordered {
 
     private final SdsClient sdsClient;
 
-    private Map<String, Function<String, Optional<SdsClient.SdsResponseData>>> sdsRequestFunctions;
+    private Map<String, BiFunction<String, String, Optional<SdsClient.SdsResponseData>>> sdsRequestFunctions;
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -81,7 +82,8 @@ public class SdsFilter implements GlobalFilter, Ordered {
     private void proceedSdsLookup(ServerWebExchange exchange, String integrationId) {
         ServerHttpRequest serverHttpRequest = exchange.getRequest();
         String organisation = extractOrganisation(serverHttpRequest.getPath());
-        SdsClient.SdsResponseData response = performRequestAccordingToInteractionId(integrationId, organisation)
+        var sspTraceId = extractSspTraceId(exchange.getRequest().getHeaders());
+        SdsClient.SdsResponseData response = performRequestAccordingToInteractionId(integrationId, organisation, sspTraceId)
             .orElseThrow(() -> new SdsException(
                 String.format("No endpoint found in SDS for GP Connect endpoint InteractionId=%s OdsCode=%s",
                     integrationId,
@@ -93,12 +95,12 @@ public class SdsFilter implements GlobalFilter, Ordered {
     }
 
     private Optional<SdsClient.SdsResponseData> performRequestAccordingToInteractionId(String interactionId,
-            String organisation) {
+            String organisation, String sspTraceId) {
         if (sdsRequestFunctions.containsKey(interactionId)) {
             LOGGER.info("Performing request with organisation \"{}\" and NHS service endpoint id \"{}\"",
                 organisation, interactionId);
             return sdsRequestFunctions.get(interactionId)
-                .apply(organisation);
+                .apply(organisation, sspTraceId);
         }
         throw new IllegalArgumentException(String.format("Not recognised InteractionId %s", interactionId));
     }
@@ -121,6 +123,17 @@ public class SdsFilter implements GlobalFilter, Ordered {
             }
         }
         return Optional.empty();
+    }
+
+    private String extractSspTraceId(HttpHeaders httpHeaders) {
+        if (httpHeaders.containsKey(SSP_TRACE_ID)) {
+            List<String> interactionIds = httpHeaders.get(SSP_TRACE_ID);
+
+            if (!CollectionUtils.isEmpty(interactionIds)) {
+                return interactionIds.get(0);
+            }
+        }
+        throw new SdsException("Missing Ssp-TraceID Header for X-Correlation-Id for SDS Request");
     }
 
     private Optional<URI> prepareLookupUri(String address, ServerHttpRequest serverHttpRequest) {

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/SdsClient.java
@@ -24,23 +24,23 @@ public class SdsClient {
     private final IParser fhirParser;
     private final SdsRequestBuilder sdsRequestBuilder;
 
-    public Optional<SdsResponseData> callForGetStructuredRecord(String fromOdsCode) {
-        var request = sdsRequestBuilder.buildGetStructuredRecordRequest(fromOdsCode);
+    public Optional<SdsResponseData> callForGetStructuredRecord(String fromOdsCode, String correlationId) {
+        var request = sdsRequestBuilder.buildGetStructuredRecordRequest(fromOdsCode, correlationId);
         return retrieveData(request);
     }
 
-    public Optional<SdsResponseData> callForPatientSearchAccessDocument(String fromOdsCode) {
-        var request = sdsRequestBuilder.buildPatientSearchAccessDocumentRequest(fromOdsCode);
+    public Optional<SdsResponseData> callForPatientSearchAccessDocument(String fromOdsCode, String correlationId) {
+        var request = sdsRequestBuilder.buildPatientSearchAccessDocumentRequest(fromOdsCode, correlationId);
         return retrieveData(request);
     }
 
-    public Optional<SdsResponseData> callForSearchForDocumentRecord(String fromOdsCode) {
-        var request = sdsRequestBuilder.buildSearchForDocumentRequest(fromOdsCode);
+    public Optional<SdsResponseData> callForSearchForDocumentRecord(String fromOdsCode, String correlationId) {
+        var request = sdsRequestBuilder.buildSearchForDocumentRequest(fromOdsCode, correlationId);
         return retrieveData(request);
     }
 
-    public Optional<SdsResponseData> callForRetrieveDocumentRecord(String fromOdsCode) {
-        var request = sdsRequestBuilder.buildRetrieveDocumentRequest(fromOdsCode);
+    public Optional<SdsResponseData> callForRetrieveDocumentRecord(String fromOdsCode, String correlationId) {
+        var request = sdsRequestBuilder.buildRetrieveDocumentRequest(fromOdsCode, correlationId);
         return retrieveData(request);
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/builder/SdsRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/builder/SdsRequestBuilder.java
@@ -37,27 +37,28 @@ public class SdsRequestBuilder {
         "urn:nhs:names:services:gpconnect:documents:fhir:rest:read:binary-1";
 
     private static final String API_KEY_HEADER = "apikey";
+    private static final String X_CORRELATION_ID_HEADER ="X-Correlation-Id";
     private final SdsConfiguration sdsConfiguration;
     private final RequestBuilderService requestBuilderService;
     private final WebClientFilterService webClientFilterService;
 
-    public WebClient.RequestHeadersSpec<?> buildGetStructuredRecordRequest(String fromOdsCode) {
-        return buildRequest(fromOdsCode, GET_STRUCTURED_INTERACTION);
+    public WebClient.RequestHeadersSpec<?> buildGetStructuredRecordRequest(String fromOdsCode, String correlationId) {
+        return buildRequest(fromOdsCode, GET_STRUCTURED_INTERACTION, correlationId);
     }
 
-    public WebClient.RequestHeadersSpec<?> buildPatientSearchAccessDocumentRequest(String fromOdsCode) {
-        return buildRequest(fromOdsCode, PATIENT_SEARCH_ACCESS_DOCUMENT_INTERACTION);
+    public WebClient.RequestHeadersSpec<?> buildPatientSearchAccessDocumentRequest(String fromOdsCode, String correlationId) {
+        return buildRequest(fromOdsCode, PATIENT_SEARCH_ACCESS_DOCUMENT_INTERACTION, correlationId);
     }
 
-    public WebClient.RequestHeadersSpec<?> buildSearchForDocumentRequest(String fromOdsCode) {
-        return buildRequest(fromOdsCode, SEARCH_FOR_DOCUMENT_INTERACTION);
+    public WebClient.RequestHeadersSpec<?> buildSearchForDocumentRequest(String fromOdsCode, String correlationId) {
+        return buildRequest(fromOdsCode, SEARCH_FOR_DOCUMENT_INTERACTION, correlationId);
     }
 
-    public WebClient.RequestHeadersSpec<?> buildRetrieveDocumentRequest(String fromOdsCode) {
-        return buildRequest(fromOdsCode, RETRIEVE_DOCUMENT_INTERACTION);
+    public WebClient.RequestHeadersSpec<?> buildRetrieveDocumentRequest(String fromOdsCode, String correlationId) {
+        return buildRequest(fromOdsCode, RETRIEVE_DOCUMENT_INTERACTION, correlationId);
     }
 
-    private WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> buildRequest(String odsCode, String interaction) {
+    private WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> buildRequest(String odsCode, String interaction, String correlationId) {
         var sslContext = requestBuilderService.buildSSLContext();
         var httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
         return buildWebClient(httpClient)
@@ -67,7 +68,8 @@ public class SdsRequestBuilder {
                 .queryParam(ORG_CODE_PARAMETER, ORG_CODE_IDENTIFIER + PIPE + odsCode)
                 .queryParam(INTERACTION_PARAMETER, INTERACTION_IDENTIFIER + PIPE + interaction)
                 .build())
-            .header(API_KEY_HEADER, sdsConfiguration.getApiKey());
+            .header(API_KEY_HEADER, sdsConfiguration.getApiKey())
+            .header(X_CORRELATION_ID_HEADER, correlationId);
     }
 
     private WebClient buildWebClient(HttpClient httpClient) {

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/builder/SdsRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/sds/builder/SdsRequestBuilder.java
@@ -37,7 +37,7 @@ public class SdsRequestBuilder {
         "urn:nhs:names:services:gpconnect:documents:fhir:rest:read:binary-1";
 
     private static final String API_KEY_HEADER = "apikey";
-    private static final String X_CORRELATION_ID_HEADER ="X-Correlation-Id";
+    private static final String X_CORRELATION_ID_HEADER = "X-Correlation-Id";
     private final SdsConfiguration sdsConfiguration;
     private final RequestBuilderService requestBuilderService;
     private final WebClientFilterService webClientFilterService;
@@ -58,7 +58,8 @@ public class SdsRequestBuilder {
         return buildRequest(fromOdsCode, RETRIEVE_DOCUMENT_INTERACTION, correlationId);
     }
 
-    private WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> buildRequest(String odsCode, String interaction, String correlationId) {
+    private WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> buildRequest(String odsCode, String interaction,
+        String correlationId) {
         var sslContext = requestBuilderService.buildSSLContext();
         var httpClient = HttpClient.create().secure(t -> t.sslContext(sslContext));
         return buildWebClient(httpClient)


### PR DESCRIPTION
* SdsRequestBuilder uses X-Correlation-Id header when making requests to SDS
* SdsFilter now extracts Ssp-TraceID which is used for the X-Correlation-Id
* Added component tests to test that X-Correlation-Id is present, and valid UUID