### PR TITLE
Updated dockerfile to pin specific Gradle version

### DIFF
--- a/docker/gpcc-mocks/Dockerfile
+++ b/docker/gpcc-mocks/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk11 AS build
+FROM gradle:6.9.4-jdk11 AS build
 
 COPY --chown=gradle:gradle gpcc-mocks /home/gradle/gpcc-mocks
 

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk11-hotspot AS build
+FROM gradle:6.9.4-jdk11 AS build
 
 COPY --chown=gradle:gradle service /home/gradle/service
 

--- a/gpcc-mocks/gradle/wrapper/gradle-wrapper.properties
+++ b/gpcc-mocks/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/service/gradle/wrapper/gradle-wrapper.properties
+++ b/service/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gpc/consumer/web/RequestBuilderService.java
@@ -33,5 +33,4 @@ public class RequestBuilderService {
                 configurer -> configurer.defaultCodecs()
                     .maxInMemorySize(BYTE_COUNT)).build();
     }
-    
 }


### PR DESCRIPTION
Updated gradle wrapper version to use gradle 6.9.4

Used 6.9.4 as 6.8.2 is not supported on DockerHub